### PR TITLE
refactor: use package/project URL in hover message

### DIFF
--- a/src/hover/hoverProvider.ts
+++ b/src/hover/hoverProvider.ts
@@ -2,8 +2,7 @@ import * as vscode from "vscode";
 
 import { dependencyRegexp } from "@/common";
 import { extractDependency } from "@/extractDependency";
-import { getPackage } from "@/package";
-import { Package } from "@/types";
+import { buildHoverMessage, getPackage } from "@/package";
 
 export class HoverProvider implements vscode.HoverProvider {
   public async provideHover(
@@ -25,12 +24,8 @@ export class HoverProvider implements vscode.HoverProvider {
       return;
     }
 
-    const message = this.buildMessage(pkg);
+    const message = buildHoverMessage(pkg);
     const link = new vscode.Hover(message, range);
     return link;
-  }
-
-  public buildMessage(pkg: Package): string {
-    return `${pkg.info.summary}\n\nLatest version: ${pkg.info.version}\n\n${pkg.info.home_page}`;
   }
 }

--- a/src/package.ts
+++ b/src/package.ts
@@ -23,3 +23,21 @@ export async function getPackage(name: string): Promise<Package | undefined> {
 
   return undefined;
 }
+
+export function buildHoverMessage(pkg: Package): string {
+  const url = (() => {
+    // Select URL to display by following the order
+    // - home_page
+    // - project_url
+    // - package_url
+    if (pkg.info.home_page !== "") {
+      return pkg.info.home_page;
+    }
+    if (pkg.info.project_url !== "") {
+      return pkg.info.project_url;
+    }
+    return pkg.info.package_url;
+  })();
+
+  return `${pkg.info.summary}\n\nLatest version: ${pkg.info.version}\n\n${url}`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export interface Info {
   name: string;
   summary: string;
   home_page: string;
+  package_url: string;
+  project_url: string;
   version: string;
 }
 

--- a/test/package.spec.ts
+++ b/test/package.spec.ts
@@ -1,8 +1,25 @@
-import { getPackage } from "@/package";
+import { buildHoverMessage, getPackage } from "@/package";
+import { Package } from "@/types";
 
-test("getPackageInformation", async () => {
+test("getPackage", async () => {
   const pkg = await getPackage("urllib3");
+  expect(pkg).not.toBeNull();
   expect(pkg?.info?.summary).toBe(
     "HTTP library with thread-safe connection pooling, file post, and more."
   );
+});
+
+test("buildHoverMessage", () => {
+  const pkg: Package = {
+    info: {
+      home_page: "",
+      name: "django-crispy-forms",
+      package_url: "",
+      project_url: "https://pypi.org/project/django-crispy-forms/",
+      summary: "Best way to have Django DRY forms",
+      version: "2.0",
+    },
+  };
+  const hoverMessage = buildHoverMessage(pkg);
+  expect(hoverMessage).toContain(pkg.info.project_url);
 });


### PR DESCRIPTION
Use package/project URL if homepage URL is missing/empty. (Re-implement #122) 